### PR TITLE
サイトダウン監視用スクリプト追加

### DIFF
--- a/access_monitoring/conf/access_monitoring_conf.sh
+++ b/access_monitoring/conf/access_monitoring_conf.sh
@@ -14,7 +14,7 @@ INC_URL='https://www.cpr-inc.jp/'
 SOLUTION_URL='https://www.cpr-inc.jp/solution/'
 
 # 通知関連
-SEND_CHANNEL="#10_solution"
+SEND_CHANNEL="#access_monitoring"
 SEND_ICON_NAME=":warning:"
 SEND_USER_NAME="監視bot"
 SEND_MASSAGE_TMPLATE=$(cat <<-EOD
@@ -28,4 +28,5 @@ url
 status_code
 ■エラーメッセージ
 error_massage
-EOD)
+EOD
+)

--- a/access_monitoring/conf/access_monitoring_conf.sh
+++ b/access_monitoring/conf/access_monitoring_conf.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+##################################
+# 【スクリプト説明】
+#   CPR内サイトのダウン監視スクリプトの定義ファイル
+# 【引数】
+#   なし
+##################################
+# 各種パス
+NOTIFICATION_SCRIPT=$SCRIPT_DIR/slack_notification.sh
+
+# 各種URL
+STDIO_URL='https://cpr-studio.jp/'
+INC_URL='https://www.cpr-inc.jp/'
+SOLUTION_URL='https://www.cpr-inc.jp/solution/'
+
+# 通知関連
+SEND_CHANNEL="#10_solution"
+SEND_ICON_NAME=":warning:"
+SEND_USER_NAME="監視bot"
+SEND_MASSAGE_TMPLATE=$(cat <<-EOD
+<!channel>
+下記サイトがサイトダウンしています。
+状況確認並びに復旧対応をお願い致します。
+
+■環境
+url
+■HTTPステータスコード
+status_code
+■エラーメッセージ
+error_massage
+EOD)

--- a/access_monitoring/script/access_monitoring.sh
+++ b/access_monitoring/script/access_monitoring.sh
@@ -41,13 +41,12 @@ function access_monitoring () {
 
   # 問い合わせ
   status_code=`curl -LI -m 45 $url -o /dev/null -w '%{http_code}\n' -s`
-#  if [ 200 -ne $status_code ]; then
+  if [ 200 -ne $status_code ]; then
     error_massage=`curl -LI -m 45 $url -sS -o /dev/null 2>&1`
-    echo $error_massage
     massage=`echo "$SEND_MASSAGE_TMPLATE" | sed "s|url|$url|" | sed "s|status_code|$status_code|" | sed "s|error_massage|$error_massage|"`
     $NOTIFICATION_SCRIPT -c $SEND_CHANNEL -u $SEND_USER_NAME -m "$massage" -i $SEND_ICON_NAME
-#    return 2
-#  fi
+    return 2
+  fi
   return 1
 }
 

--- a/access_monitoring/script/access_monitoring.sh
+++ b/access_monitoring/script/access_monitoring.sh
@@ -15,7 +15,7 @@ source $SCRIPT_DIR/../conf/access_monitoring_conf.sh
 ##################################
 # function
 ##################################
-function access_monitoring () {
+access_monitoring () {
 
   # 変数の初期化
   unset url

--- a/access_monitoring/script/access_monitoring.sh
+++ b/access_monitoring/script/access_monitoring.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+##################################
+# 【スクリプト説明】
+#   CPR内サイトのダウン監視スクリプト
+# 【引数】
+#   なし
+##################################
+
+##################################
+# define
+##################################
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+source $SCRIPT_DIR/../conf/access_monitoring_conf.sh
+
+##################################
+# function
+##################################
+function access_monitoring () {
+
+  # 変数の初期化
+  unset url
+  unset error_massage
+
+  # 引数に応じて問い合わせ先を変更する。
+  case $1 in
+  STDIO)
+      url=$STDIO_URL
+      ;;
+  INC)
+      url=$INC_URL
+      ;;
+  SOLUTION)
+      url=$SOLUTION_URL
+      ;;
+  esac
+
+  # 想定している引数ではない場合に返却
+  if [ -z "$url" ]; then
+    return 2
+  fi
+
+  # 問い合わせ
+  status_code=`curl -LI -m 45 $url -o /dev/null -w '%{http_code}\n' -s`
+#  if [ 200 -ne $status_code ]; then
+    error_massage=`curl -LI -m 45 $url -sS -o /dev/null 2>&1`
+    echo $error_massage
+    massage=`echo "$SEND_MASSAGE_TMPLATE" | sed "s|url|$url|" | sed "s|status_code|$status_code|" | sed "s|error_massage|$error_massage|"`
+    $NOTIFICATION_SCRIPT -c $SEND_CHANNEL -u $SEND_USER_NAME -m "$massage" -i $SEND_ICON_NAME
+#    return 2
+#  fi
+  return 1
+}
+
+##################################
+# Main
+##################################
+# スタジオの稼働確認
+access_monitoring  'STDIO'
+# incの稼働確認
+access_monitoring 'INC'
+# ソリューションの稼働確認
+access_monitoring 'SOLUTION'
+# 異常系テスト用
+access_monitoring '異常系'

--- a/access_monitoring/script/slack_notification.sh
+++ b/access_monitoring/script/slack_notification.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+##################################
+# 【スクリプト説明】
+#   スラック通知を行うスクリプト
+# 【引数】
+#   -c：sending channel
+#   -m：sending massage
+#   -h or --help：help
+##################################
+
+##################################
+# define
+##################################
+# デフォルト値
+URL='https://slack.com/api/chat.postMessage'
+#channel="#10_solution"
+TOKEN="xoxp-158553217862-170022896451-1068445004305-2eeef5f30053f2db4241a2c3994c6663"
+username="通知bot"
+channel="#test_api_send"
+massege="Botからの送信です。"
+
+##################################
+# function
+##################################
+usage() {
+  cat <<EOM
+Usage: $(basename "$0") [OPTION]...
+  -h or --help         Display help
+  -c or --channel VALUE    Destination channel setting (default: #10_solution)
+  -m or --massege VALUE    Destination massege setting (default: "Botからの送信です。")
+  -i or --icon    VALUE    Destination icon setting
+  -u or --user    VALUE    Destination user name setting (default: "通知bot")
+EOM
+
+  exit 2
+}
+
+##################################
+# Main
+##################################
+# 引数別の処理定義
+while getopts "h:c:m:u:i:-:" optkey; do
+  optarg="$OPTARG"
+  if [[ "$optkey" = - ]]; then
+      optkey="-${OPTARG%%=*}"
+      optarg="${OPTARG/${OPTARG%%=*}/}"
+      optarg="${optarg#=}"
+
+      if [[ -z "$optarg" ]] && [[ ! "${!OPTIND}" = -* ]]; then
+          optarg="${!OPTIND}"
+          shift
+      fi
+  fi
+
+  case "$optkey" in
+    'c'|'-channel')
+      channel=$optarg
+      ;;
+    'm'|'-massege')
+      massege=$optarg
+      ;;
+    'u'|'-user')
+      username=$optarg
+      ;;
+    'i'|'-icon')
+      icon_emoji=$optarg
+      ;;
+    '-h'|'-help'|* )
+      usage
+      ;;
+  esac
+done
+
+# 問い合わせ
+curl -XPOST "$URL" -d "token=$TOKEN" -d "channel=$channel" -d "text=$massege" -d "username=$username" -d "icon_emoji=$icon_emoji"
+
+# 各種Payload
+echo $channel
+echo $icon_emoji
+echo $username
+echo $massege

--- a/access_monitoring/script/slack_notification.sh
+++ b/access_monitoring/script/slack_notification.sh
@@ -5,6 +5,8 @@
 # 【引数】
 #   -c：sending channel
 #   -m：sending massage
+#   -i：sending icon
+#   -u：sending user name
 #   -h or --help：help
 ##################################
 
@@ -13,10 +15,9 @@
 ##################################
 # デフォルト値
 URL='https://slack.com/api/chat.postMessage'
-#channel="#10_solution"
-TOKEN="xoxp-158553217862-170022896451-1068445004305-2eeef5f30053f2db4241a2c3994c6663"
+TOKEN="認証トークン"
 username="通知bot"
-channel="#test_api_send"
+channel="#10_solution"
 massege="Botからの送信です。"
 
 ##################################
@@ -73,9 +74,3 @@ done
 
 # 問い合わせ
 curl -XPOST "$URL" -d "token=$TOKEN" -d "channel=$channel" -d "text=$massege" -d "username=$username" -d "icon_emoji=$icon_emoji"
-
-# 各種Payload
-echo $channel
-echo $icon_emoji
-echo $username
-echo $massege


### PR DESCRIPTION
## 概要
CPR内で管理しているサイトのサイトダウン監視とダウン時のslack通知処理を追加します。
## 仕様書
http://cpr-inc.synology.me/dokuwiki/doku.php?id=start:solution_internal_system:access_monitoring
## 各ファイルでの処理概要
#### ＜access_monitoring.sh＞
メイン処理スクリプト
下記の順番で「HTTPリクエスト」を実施し、「HTTPステータスコード」が200以外の場合にSlack通知用スクリプトを呼び出す。

＜リクエスト順＞
```
１：スタジオ
２：INC
３：ソリューション
```
#### ＜access_monitoring_conf.sh＞
定義ファイルスクリプト
各HTTPリクエスト先や通知時のメッセージテンプレートを定義
#### ＜slack_notification.sh＞
起動時のパラメータを元にslackへ通知を行います。
各オプション毎の設定項目は下記となります。

```
  -h or --help：ヘルプ表示
  -c or --channel VALUE：送信先チャンネル
  -m or --massege VALUE：送信先メッセージ
  -i or --icon    VALUE：アイコン
  -u or --user    VALUE：通知時の名称
```
## 認証トークンに関して
上記設計書内に記載